### PR TITLE
Allow use of non-timestamp out-of-date checking schemes

### DIFF
--- a/lsjs.js
+++ b/lsjs.js
@@ -224,7 +224,7 @@ var define;
 			if (scriptText) {
 				_inject(expandedId, dependentId, cb, scriptText);
 			} else if (storedModule === undefined || storedModule === null) {
-				_getModule(url, function(_url, scriptSrc, ts) {
+				_getModule(url, cfg.timestampHeader, function(_url, scriptSrc, ts) {
 					var entry = {url: _url, timestamp: ts};
 					loaded[_url] = ts;
 					storage.set("loaded!"+window.location.pathname, loaded);
@@ -271,13 +271,13 @@ var define;
 		});
 	};
 
-	function _getModule(url, cb) {
+	function _getModule(url, header, cb) {
 		var xhr = new XMLHttpRequest();
 		xhr.open("GET", url+"?nocache="+new Date().valueOf(), true);
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState == 4) {
 				if (xhr.status == 200) {
-					cb(url, xhr.responseText, xhr.getResponseHeader("Last-Modified"));
+					cb(url, xhr.responseText, xhr.getResponseHeader(header));
 				} else {
 					throw new Error("Unable to load ["+url+"]:"+xhr.status);
 				}
@@ -386,7 +386,7 @@ var define;
 				if (pluginName in usesCache) {
 					var url = _idToUrl(pluginModuleName);
 					if (cache[url] === undefined || url in reload) {
-						_getLastModified(url, function(lastModified){
+						_getLastModified(url, cfg.timestampHeader, function(lastModified){
 							if (lastModified) {
 								cachets[url] = lastModified;
 								_storeCache();
@@ -493,13 +493,13 @@ var define;
 		xhr.send(JSON.stringify(current));
 	};
 
-	function _getLastModified(url, cb) {
+	function _getLastModified(url, header, cb) {
 		var xhr = new XMLHttpRequest();
 		xhr.open("HEAD", url, true);
 		xhr.onreadystatechange = function() {
 			if (xhr.readyState == 4) {
 				if (xhr.status == 200) {
-					cb(xhr.getResponseHeader("Last-Modified"));
+					cb(xhr.getResponseHeader(header));
 				} else {
 					cb();
 				}
@@ -652,6 +652,10 @@ var define;
 
 			if (cfg.baseUrl.charAt(0) !== '/' && !cfg.baseUrl.match(/^[\w\+\.\-]+:/)) {
 				cfg.baseUrl = _normalize(window.location.pathname.substring(0, window.location.pathname.lastIndexOf('/')) + '/'+ cfg.baseUrl);
+			}
+
+			if (!cfg.timestampHeader) {
+				cfg.timestampHeader = "Last-Modified";
 			}
 		}
 	};


### PR DESCRIPTION
Implementing #1 

You can now use `timestampHeader` in your lsjs [config](https://github.com/zazl/lsjs/wiki/Getting-Started#configuration) like so;

```javascript
{
	//attempt to use the 'ETag' header, then use 'Last-Modified'
	timestampHeader    : ['ETag', 'Last-Modified']
}
```

Defaults to `['Last-Modified']` to maintain parity with original execution.